### PR TITLE
exclude checksum file while deno crawling

### DIFF
--- a/pkgs/crawlers/gh/lans/deno.go
+++ b/pkgs/crawlers/gh/lans/deno.go
@@ -55,6 +55,9 @@ func (d *Deno) fileFilter(a gh.Asset) bool {
 	if strings.HasSuffix(a.Name, ".deno.d.ts") {
 		return false
 	}
+	if strings.HasSuffix(a.Name, ".sha256sum") {
+		return false
+	}
 	return true
 }
 


### PR DESCRIPTION
Currently, Deno in `gvcgo/vsources` includes checksum file from `v2.0`, which prevent installation process for Deno. This PR fixes `vcollector`'s Deno crawling, excludes files with suffix ".sha256sum".